### PR TITLE
Use pretty-printed JSON in wmcp.txt

### DIFF
--- a/lua/wmcp/sv_medialist.lua
+++ b/lua/wmcp/sv_medialist.lua
@@ -18,7 +18,7 @@ else
 end
 
 local function Persist()
-	file.Write("wmcp.txt", util.TableToJSON(t))
+	file.Write("wmcp.txt", util.TableToJSON(t, true))
 end
 
 local wmcp_allowed = CreateConVar("wmcp_allowedgroup", "admin", FCVAR_ARCHIVE, "The minimum usergroup that is allowed to add/remove/play videos.")


### PR DESCRIPTION
Use pretty-printed JSON in wmcp.txt as it allows easier manual editing.
